### PR TITLE
[turbo_serializable] Allow  const constructors in sub-classes

### DIFF
--- a/turbo_serializable/lib/abstracts/t_writeable_custom_id.dart
+++ b/turbo_serializable/lib/abstracts/t_writeable_custom_id.dart
@@ -55,6 +55,8 @@ import 'package:turbo_serializable/abstracts/t_writeable.dart';
 /// }
 /// ```
 abstract class TWriteableCustomId<T> extends TWriteable {
+  const TWriteableCustomId();
+
   /// The unique identifier for this document.
   ///
   /// This getter must be implemented by subclasses to provide the document's

--- a/turbo_serializable/lib/abstracts/t_writeable_id.dart
+++ b/turbo_serializable/lib/abstracts/t_writeable_id.dart
@@ -23,6 +23,8 @@ import 'package:turbo_serializable/constants/ts_defaults.dart';
 /// }
 /// ```
 abstract class TWriteableId extends TWriteable {
+  const TWriteableId();
+
   /// The unique string identifier for this object.
   ///
   /// This getter must be implemented by subclasses to provide the object's


### PR DESCRIPTION
The abstract classes in the package rely on implicit constructors. Implicit constructors are not const. Some abstract classes can allow for declaring their constructors as const.
This allows for a subclass to be able to declare its constructor as const too.
In this PR I found some places in this package, where a const constructor is possible. I had some data-models that were const all the way down. But if I want to make the extend these abstracts, I'd have to get rid of consts everywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom ID types now support const instantiation, enabling compile-time constant creation while maintaining backward compatibility with existing implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->