### PR TITLE
feat(turbo_firestore_api): send only changed fields on document updates (PKG-32)

### DIFF
--- a/turbo_firestore_api/lib/apis/t_firestore_api.dart
+++ b/turbo_firestore_api/lib/apis/t_firestore_api.dart
@@ -13,6 +13,7 @@ import 'package:turbo_firestore_api/models/t_sensitive_data.dart';
 import 'package:turbo_firestore_api/models/t_write_batch_with_reference.dart';
 import 'package:turbo_firestore_api/typedefs/collection_reference_def.dart';
 import 'package:turbo_firestore_api/util/t_firestore_logger.dart';
+import 'package:turbo_firestore_api/util/t_map_diff.dart';
 import 'package:turbo_response/turbo_response.dart';
 import 'package:turbo_serializable/abstracts/t_writeable.dart';
 

--- a/turbo_firestore_api/lib/apis/t_firestore_update_api.dart
+++ b/turbo_firestore_api/lib/apis/t_firestore_update_api.dart
@@ -340,7 +340,10 @@ mixin TFirestoreUpdateApi<DTO> on _TFirestoreApiBase<DTO> {
         ),
       );
       final nullSafeWriteBatch = writeBatch ?? this.writeBatch;
-      final documentReference = getDocRefById(id: id);
+      final documentReference = getDocRefById(
+        id: id,
+        collectionPathOverride: collectionPathOverride,
+      );
       _log.debug(message: 'Creating JSON..', sensitiveData: null);
       final newJson = writeable.toJson();
       final Map<String, Object?> payload;

--- a/turbo_firestore_api/lib/apis/t_firestore_update_api.dart
+++ b/turbo_firestore_api/lib/apis/t_firestore_update_api.dart
@@ -200,7 +200,7 @@ mixin TFirestoreUpdateApi<DTO> on _TFirestoreApiBase<DTO> {
             ),
           );
           transaction.update(
-            getDocRefById(id: documentReference.id),
+            documentReference,
             payload,
           );
         }

--- a/turbo_firestore_api/lib/apis/t_firestore_update_api.dart
+++ b/turbo_firestore_api/lib/apis/t_firestore_update_api.dart
@@ -33,10 +33,20 @@ mixin TFirestoreUpdateApi<DTO> on _TFirestoreApiBase<DTO> {
   /// Parameters:
   /// [writeable] data to update, must implement [TWriteable]
   /// [id] unique identifier of the document
+  /// [previousWriteable] optional previous state of the writeable. When provided,
+  /// only the fields whose values differ between [previousWriteable.toJson()] and
+  /// [writeable.toJson()] are sent to Firestore (computed via [TMapDiff.diff]).
+  /// When the diff is empty the write is skipped entirely and a success
+  /// response is returned without contacting Firestore. When `null`, the full
+  /// payload is sent (backwards-compatible behavior).
   /// [writeBatch] optional batch to include this operation in
   /// [timestampType] type of timestamp to add when updating
   /// [collectionPathOverride] override path for collection groups
   /// [transaction] optional transaction to include this operation in
+  /// [includeDeletes] when `true` and [previousWriteable] is provided, fields
+  /// that exist in [previousWriteable.toJson()] but are absent from
+  /// [writeable.toJson()] are emitted as [FieldValue.delete()] entries in the
+  /// diff payload. Defaults to `false`.
   ///
   /// Returns [TurboResponse] containing:
   /// - Success with document reference
@@ -68,10 +78,12 @@ mixin TFirestoreUpdateApi<DTO> on _TFirestoreApiBase<DTO> {
   Future<TurboResponse<DocumentReference>> updateDoc({
     required TWriteable writeable,
     required String id,
+    TWriteable? previousWriteable,
     WriteBatch? writeBatch,
     TTimestampType timestampType = TTimestampType.updatedAt,
     String? collectionPathOverride,
     Transaction? transaction,
+    bool includeDeletes = false,
   }) async {
     assert(
     _isCollectionGroup == (collectionPathOverride != null),
@@ -112,9 +124,11 @@ mixin TFirestoreUpdateApi<DTO> on _TFirestoreApiBase<DTO> {
         final lastBatchResponse = await updateDocInBatch(
           writeable: writeable,
           id: id,
+          previousWriteable: previousWriteable,
           writeBatch: writeBatch,
           timestampType: timestampType,
           collectionPathOverride: collectionPathOverride,
+          includeDeletes: includeDeletes,
         );
         _log.debug(
           message: 'Checking if batchUpdate was successful..',
@@ -134,34 +148,60 @@ mixin TFirestoreUpdateApi<DTO> on _TFirestoreApiBase<DTO> {
           message: 'Creating JSON..',
           sensitiveData: null,
         );
-        final json = writeable.toJson();
-        final writeableAsJson = timestampType.add(
-          json,
-          createdAtFieldName: _createdAtFieldName,
-          updatedAtFieldName: _updatedAtFieldName,
-        );
+        final newJson = writeable.toJson();
+        final Map<String, Object?> payload;
+        if (previousWriteable == null) {
+          payload = timestampType.add(
+            newJson,
+            createdAtFieldName: _createdAtFieldName,
+            updatedAtFieldName: _updatedAtFieldName,
+          );
+        } else {
+          final beforeJson = previousWriteable.toJson();
+          final diffMap = TMapDiff.diff(
+            before: beforeJson,
+            after: newJson,
+            includeDeletes: includeDeletes,
+          );
+          if (diffMap.isEmpty) {
+            _log.debug(
+              message: 'No fields changed, skipping update for id: $id',
+              sensitiveData: null,
+            );
+            _log.info(
+              message: 'Updating data done!',
+              sensitiveData: null,
+            );
+            return TurboResponse.success(result: documentReference);
+          }
+          payload = timestampType.add(
+            diffMap,
+            createdAtFieldName: _createdAtFieldName,
+            updatedAtFieldName: _updatedAtFieldName,
+          );
+        }
         if (transaction == null) {
           _log.debug(
             message: 'Updating data with documentReference.update..',
             sensitiveData: TSensitiveData(
               path: collectionPathOverride ?? _collectionPath(),
               id: documentReference.id,
-              data: writeableAsJson,
+              data: payload,
             ),
           );
-          await documentReference.update(writeableAsJson);
+          await documentReference.update(payload);
         } else {
           _log.debug(
             message: 'Updating data with transaction.update..',
             sensitiveData: TSensitiveData(
               path: collectionPathOverride ?? _collectionPath(),
               id: documentReference.id,
-              data: writeableAsJson,
+              data: payload,
             ),
           );
           transaction.update(
             getDocRefById(id: documentReference.id),
-            writeableAsJson,
+            payload,
           );
         }
         _log.info(
@@ -217,9 +257,19 @@ mixin TFirestoreUpdateApi<DTO> on _TFirestoreApiBase<DTO> {
   /// Parameters:
   /// [writeable] data to update, must implement [TWriteable]
   /// [id] unique identifier of the document
+  /// [previousWriteable] optional previous state of the writeable. When provided,
+  /// only the fields whose values differ between [previousWriteable.toJson()] and
+  /// [writeable.toJson()] are enqueued on the batch (computed via
+  /// [TMapDiff.diff]). When the diff is empty no operation is enqueued and a
+  /// success response wrapping the unchanged batch is returned. When `null`,
+  /// the full payload is enqueued (backwards-compatible behavior).
   /// [writeBatch] optional existing batch to add to
   /// [timestampType] type of timestamp to add when updating
   /// [collectionPathOverride] override path for collection groups
+  /// [includeDeletes] when `true` and [previousWriteable] is provided, fields
+  /// that exist in [previousWriteable.toJson()] but are absent from
+  /// [writeable.toJson()] are emitted as [FieldValue.delete()] entries in the
+  /// diff payload. Defaults to `false`.
   ///
   /// Returns [TurboResponse] containing:
   /// - Success with batch and document reference
@@ -257,9 +307,11 @@ mixin TFirestoreUpdateApi<DTO> on _TFirestoreApiBase<DTO> {
   updateDocInBatch({
     required TWriteable writeable,
     required String id,
+    TWriteable? previousWriteable,
     WriteBatch? writeBatch,
     TTimestampType timestampType = TTimestampType.updatedAt,
     String? collectionPathOverride,
+    bool includeDeletes = false,
   }) async {
     assert(
     _isCollectionGroup == (collectionPathOverride != null),
@@ -290,23 +342,55 @@ mixin TFirestoreUpdateApi<DTO> on _TFirestoreApiBase<DTO> {
       final nullSafeWriteBatch = writeBatch ?? this.writeBatch;
       final documentReference = getDocRefById(id: id);
       _log.debug(message: 'Creating JSON..', sensitiveData: null);
-      final json = writeable.toJson();
-      final writeableAsJson = timestampType.add(
-        json,
-        createdAtFieldName: _createdAtFieldName,
-        updatedAtFieldName: _updatedAtFieldName,
-      );
+      final newJson = writeable.toJson();
+      final Map<String, Object?> payload;
+      if (previousWriteable == null) {
+        payload = timestampType.add(
+          newJson,
+          createdAtFieldName: _createdAtFieldName,
+          updatedAtFieldName: _updatedAtFieldName,
+        );
+      } else {
+        final beforeJson = previousWriteable.toJson();
+        final diffMap = TMapDiff.diff(
+          before: beforeJson,
+          after: newJson,
+          includeDeletes: includeDeletes,
+        );
+        if (diffMap.isEmpty) {
+          _log.debug(
+            message: 'No fields changed, skipping update for id: $id',
+            sensitiveData: null,
+          );
+          _log.info(
+            message:
+                'Adding update to batch done! Returning WriteBatchWithReference..',
+            sensitiveData: null,
+          );
+          return TurboResponse.success(
+            result: TWriteBatchWithReference(
+              writeBatch: nullSafeWriteBatch,
+              documentReference: documentReference,
+            ),
+          );
+        }
+        payload = timestampType.add(
+          diffMap,
+          createdAtFieldName: _createdAtFieldName,
+          updatedAtFieldName: _updatedAtFieldName,
+        );
+      }
       _log.debug(
         message: 'Updating data with writeBatch.update..',
         sensitiveData: TSensitiveData(
           path: collectionPathOverride ?? _collectionPath(),
           id: documentReference.id,
-          data: writeableAsJson,
+          data: payload,
         ),
       );
       nullSafeWriteBatch.update(
         documentReference,
-        writeableAsJson,
+        payload,
       );
       _log.info(
         message:

--- a/turbo_firestore_api/lib/services/t_collection_service.dart
+++ b/turbo_firestore_api/lib/services/t_collection_service.dart
@@ -706,9 +706,10 @@ class TCollectionService<DTO extends TWriteableId, MODEL extends TModel<DTO>>
   /// Sends only fields that changed since the last known local state. The
   /// pre-mutation DTO is captured before the local state is updated and
   /// forwarded to the API as `previousWriteable` so the API can compute a
-  /// minimal diff payload (and skip the write entirely on a no-op). When no
-  /// document with [id] exists in local state the previous DTO is `null` and
-  /// the API falls back to a full-payload write.
+  /// minimal diff payload (and skip the write entirely on a no-op).
+  ///
+  /// The document with [id] must already exist in local state before calling
+  /// this method.
   ///
   /// If [remoteUpdateRequestBuilder] is provided, it must be deterministic —
   /// it is applied to BOTH the previous DTO and the new DTO so the diff

--- a/turbo_firestore_api/lib/services/t_collection_service.dart
+++ b/turbo_firestore_api/lib/services/t_collection_service.dart
@@ -703,6 +703,17 @@ class TCollectionService<DTO extends TWriteableId, MODEL extends TModel<DTO>>
   /// then syncing with Firestore. If the remote update fails, the local
   /// state remains updated.
   ///
+  /// Sends only fields that changed since the last known local state. The
+  /// pre-mutation DTO is captured before the local state is updated and
+  /// forwarded to the API as `previousWriteable` so the API can compute a
+  /// minimal diff payload (and skip the write entirely on a no-op). When no
+  /// document with [id] exists in local state the previous DTO is `null` and
+  /// the API falls back to a full-payload write.
+  ///
+  /// If [remoteUpdateRequestBuilder] is provided, it must be deterministic —
+  /// it is applied to BOTH the previous DTO and the new DTO so the diff
+  /// inputs share the same shape.
+  ///
   /// Parameters:
   /// - [transaction] - Optional transaction for atomic operations
   /// - [id] - The ID of the document to update
@@ -721,13 +732,22 @@ class TCollectionService<DTO extends TWriteableId, MODEL extends TModel<DTO>>
   }) async {
     try {
       log.debug('Updating doc with id: $id');
+      final DTO? previousDto = tryFindById(id)?.dto;
       final pDoc = updateLocalDoc(
         id: id,
         doc: doc,
         doNotifyListeners: doNotifyListeners,
       );
+      final TWriteableId newWriteable =
+          remoteUpdateRequestBuilder?.call(pDoc) ?? pDoc as TWriteableId;
+      final TWriteableId? previousForRemote = previousDto == null
+          ? null
+          : (remoteUpdateRequestBuilder != null
+              ? remoteUpdateRequestBuilder(previousDto)
+              : previousDto as TWriteableId);
       final future = api.updateDoc(
-        writeable: remoteUpdateRequestBuilder?.call(pDoc) ?? pDoc as TWriteableId,
+        writeable: newWriteable,
+        previousWriteable: previousForRemote,
         id: id,
         transaction: transaction,
       );
@@ -815,6 +835,10 @@ class TCollectionService<DTO extends TWriteableId, MODEL extends TModel<DTO>>
   }) async {
     try {
       log.debug('Updating ${ids.length} docs');
+      final Map<String, DTO> previousDtos = <String, DTO>{
+        for (final id in ids)
+          if (tryFindById(id)?.dto case final DTO previousDto) id: previousDto,
+      };
       final pDocs = updateLocalDocs(
         ids: ids,
         doc: doc,
@@ -826,6 +850,7 @@ class TCollectionService<DTO extends TWriteableId, MODEL extends TModel<DTO>>
             id: pDoc.id,
             transaction: transaction,
             writeable: pDoc as TWriteableId,
+            previousWriteable: previousDtos[pDoc.id] as TWriteableId?,
           )).throwWhenFail();
         }
         return TurboResponse.success(result: pDocs);
@@ -836,6 +861,7 @@ class TCollectionService<DTO extends TWriteableId, MODEL extends TModel<DTO>>
             id: pDoc.id,
             writeBatch: batch,
             writeable: pDoc as TWriteableId,
+            previousWriteable: previousDtos[pDoc.id] as TWriteableId?,
           );
         }
         final future = batch.commit();

--- a/turbo_firestore_api/lib/services/t_doc_service.dart
+++ b/turbo_firestore_api/lib/services/t_doc_service.dart
@@ -415,6 +415,15 @@ class TDocService<DTO extends TWriteableId, MODEL extends TModel<DTO>> extends T
   /// then syncing with Firestore. If the remote update fails, the local
   /// state remains updated.
   ///
+  /// Sends only fields that changed since the last known local state. The
+  /// pre-mutation DTO is captured before the local state is updated and
+  /// forwarded to the API as `previousWriteable` so the API can compute a
+  /// minimal diff payload (and skip the write entirely on a no-op).
+  ///
+  /// If [remoteUpdateRequestBuilder] is provided, it must be deterministic —
+  /// it is applied to BOTH the previous DTO and the new DTO so the diff
+  /// inputs share the same shape.
+  ///
   /// Parameters:
   /// - [id] - The document ID
   /// - [doc] - The function to update the document
@@ -433,13 +442,20 @@ class TDocService<DTO extends TWriteableId, MODEL extends TModel<DTO>> extends T
   }) async {
     try {
       log.debug('Updating doc with id: $id');
+      final DTO previousDto = _doc.value.dto;
       final pDoc = updateLocalDoc(
         id: id,
         doc: doc,
         doNotifyListeners: doNotifyListeners,
       );
+      final TWriteable newWriteable =
+          remoteUpdateRequestBuilder?.call(pDoc) ?? pDoc as TWriteable;
+      final TWriteable previousForRemote = remoteUpdateRequestBuilder != null
+          ? remoteUpdateRequestBuilder(previousDto)
+          : previousDto as TWriteable;
       final future = api.updateDoc(
-        writeable: remoteUpdateRequestBuilder?.call(pDoc) ?? pDoc as TWriteable,
+        writeable: newWriteable,
+        previousWriteable: previousForRemote,
         id: id,
         transaction: transaction,
       );

--- a/turbo_firestore_api/lib/util/t_map_diff.dart
+++ b/turbo_firestore_api/lib/util/t_map_diff.dart
@@ -1,0 +1,102 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:collection/collection.dart';
+
+/// A utility class for computing Firestore-friendly diffs between two map
+/// snapshots.
+///
+/// Returns a Firestore update()-ready map of dot-notation field paths
+/// representing the difference between [before] and [after].
+///
+/// - [before] null  -> shallow copy of [after]
+/// - deeply equal   -> {} (caller skips write)
+/// - nested maps    -> flattened with dot notation (siblings preserved)
+/// - lists          -> atomic replace if not deep-equal
+/// - removed keys   -> FieldValue.delete() ONLY when [includeDeletes] is true
+class TMapDiff {
+  /// Returns a Firestore update()-ready map of dot-notation field paths
+  /// representing the difference between [before] and [after].
+  ///
+  /// Behavior:
+  /// - When [before] is `null`, returns a shallow copy of [after] (top-level
+  ///   keys emitted as-is, no flattening).
+  /// - When [before] is deeply equal to [after], returns an empty map so
+  ///   callers can skip the write entirely.
+  /// - For each key in [after]:
+  ///   - If [before] does not contain the key, emits `{key: afterValue}` at
+  ///     the current dot-notation path (no recursion when one side is absent).
+  ///   - If both `beforeValue` and `afterValue` are `Map<String, dynamic>`,
+  ///     recurses with prefix `${currentPath}.${key}`.
+  ///   - Else if `DeepCollectionEquality().equals(beforeValue, afterValue)`,
+  ///     skips the entry.
+  ///   - Else emits `{path: afterValue}`.
+  /// - When [includeDeletes] is `true`, also walks keys present in [before]
+  ///   but missing from [after] and emits `{path: FieldValue.delete()}`.
+  /// - Lists are not recursed into; they are compared atomically by
+  ///   [DeepCollectionEquality] and replaced wholesale if not equal.
+  static Map<String, Object?> diff({
+    required Map<String, dynamic>? before,
+    required Map<String, dynamic> after,
+    bool includeDeletes = false,
+  }) {
+    if (before == null) {
+      return Map<String, Object?>.from(after);
+    }
+    const equality = DeepCollectionEquality();
+    if (equality.equals(before, after)) {
+      return <String, Object?>{};
+    }
+    final result = <String, Object?>{};
+    _collect(
+      before: before,
+      after: after,
+      prefix: '',
+      includeDeletes: includeDeletes,
+      result: result,
+      equality: equality,
+    );
+    return result;
+  }
+
+  static void _collect({
+    required Map<String, dynamic> before,
+    required Map<String, dynamic> after,
+    required String prefix,
+    required bool includeDeletes,
+    required Map<String, Object?> result,
+    required DeepCollectionEquality equality,
+  }) {
+    for (final entry in after.entries) {
+      final key = entry.key;
+      final afterValue = entry.value;
+      final path = prefix.isEmpty ? key : '$prefix.$key';
+      if (!before.containsKey(key)) {
+        result[path] = afterValue;
+        continue;
+      }
+      final beforeValue = before[key];
+      if (beforeValue is Map<String, dynamic> &&
+          afterValue is Map<String, dynamic>) {
+        _collect(
+          before: beforeValue,
+          after: afterValue,
+          prefix: path,
+          includeDeletes: includeDeletes,
+          result: result,
+          equality: equality,
+        );
+        continue;
+      }
+      if (equality.equals(beforeValue, afterValue)) {
+        continue;
+      }
+      result[path] = afterValue;
+    }
+    if (includeDeletes) {
+      for (final key in before.keys) {
+        if (after.containsKey(key)) continue;
+        final path = prefix.isEmpty ? key : '$prefix.$key';
+        result[path] = FieldValue.delete();
+      }
+    }
+  }
+}

--- a/turbo_firestore_api/pubspec.yaml
+++ b/turbo_firestore_api/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 
 dependencies:
   cloud_firestore: ^6.1.2
+  collection: ^1.18.0
   firebase_auth: ^6.1.4
   flutter:
     sdk: flutter

--- a/turbo_firestore_api/test/apis/t_firestore_update_api_test.dart
+++ b/turbo_firestore_api/test/apis/t_firestore_update_api_test.dart
@@ -1,0 +1,309 @@
+// ignore_for_file: subtype_of_sealed_class
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:turbo_firestore_api/apis/t_firestore_api.dart';
+import 'package:turbo_response/turbo_response.dart';
+import 'package:turbo_serializable/abstracts/t_writeable.dart';
+
+/// Hand-rolled writeable that returns a preset map from [toJson].
+class _MapWriteable extends TWriteable {
+  _MapWriteable(this._json);
+
+  final Map<String, dynamic> _json;
+
+  @override
+  Map<String, dynamic> toJson() => _json;
+}
+
+/// Captures `update(...)` calls on a delegated [DocumentReference] so tests
+/// can inspect the exact map passed to Firestore.
+// ignore: must_be_immutable
+class _RecordingDocumentReference
+    implements DocumentReference<Map<String, dynamic>> {
+  _RecordingDocumentReference(this._inner);
+
+  final DocumentReference<Map<String, dynamic>> _inner;
+  Map<Object, Object?>? capturedUpdate;
+  int updateCallCount = 0;
+
+  @override
+  Future<void> update(Map<Object, Object?> data) async {
+    updateCallCount++;
+    capturedUpdate = Map<Object, Object?>.from(data);
+  }
+
+  @override
+  String get id => _inner.id;
+
+  @override
+  String get path => _inner.path;
+
+  @override
+  FirebaseFirestore get firestore => _inner.firestore;
+
+  @override
+  CollectionReference<Map<String, dynamic>> get parent => _inner.parent;
+
+  @override
+  CollectionReference<Map<String, dynamic>> collection(String collectionPath) =>
+      _inner.collection(collectionPath);
+
+  @override
+  Future<void> delete() => _inner.delete();
+
+  @override
+  Future<DocumentSnapshot<Map<String, dynamic>>> get([GetOptions? options]) =>
+      _inner.get(options);
+
+  @override
+  Stream<DocumentSnapshot<Map<String, dynamic>>> snapshots({
+    bool includeMetadataChanges = false,
+    ListenSource source = ListenSource.defaultSource,
+  }) =>
+      _inner.snapshots(
+        includeMetadataChanges: includeMetadataChanges,
+        source: source,
+      );
+
+  @override
+  Future<void> set(Map<String, dynamic> data, [SetOptions? options]) =>
+      _inner.set(data, options);
+
+  @override
+  DocumentReference<R> withConverter<R>({
+    required FromFirestore<R> fromFirestore,
+    required ToFirestore<R> toFirestore,
+  }) =>
+      _inner.withConverter<R>(
+        fromFirestore: fromFirestore,
+        toFirestore: toFirestore,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is _RecordingDocumentReference && other._inner == _inner;
+
+  @override
+  int get hashCode => _inner.hashCode;
+}
+
+/// Captures `update(...)` calls enqueued onto a [WriteBatch] so tests can
+/// inspect the payload without committing.
+class _RecordingWriteBatch implements WriteBatch {
+  _RecordingWriteBatch();
+
+  Map<Object, Object?>? capturedUpdate;
+  int updateCallCount = 0;
+
+  @override
+  void update(DocumentReference<Object?> document, Map<Object, Object?> data) {
+    updateCallCount++;
+    capturedUpdate = Map<Object, Object?>.from(data);
+  }
+
+  @override
+  Future<void> commit() async {}
+
+  @override
+  void delete(DocumentReference<Object?> document) {}
+
+  @override
+  void set<T>(
+    DocumentReference<T> document,
+    T data, [
+    SetOptions? options,
+  ]) {}
+}
+
+/// [TFirestoreApi] subclass that always hands out the same recording
+/// [DocumentReference], so tests can capture the exact `update(...)` payload.
+class _RecordingApi extends TFirestoreApi<TWriteable> {
+  _RecordingApi({
+    required super.firebaseFirestore,
+    required super.collectionPath,
+    required this.recordingRef,
+  });
+
+  final _RecordingDocumentReference recordingRef;
+
+  @override
+  DocumentReference<Map<String, dynamic>> getDocRefById({
+    required String id,
+    String? collectionPathOverride,
+  }) {
+    return recordingRef;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeFirebaseFirestore firestore;
+  late _RecordingDocumentReference recordingRef;
+  late _RecordingApi api;
+
+  setUp(() async {
+    firestore = FakeFirebaseFirestore();
+    // Seed the document so `update()` would succeed on a real Firestore;
+    // for the recording proxy this is purely to keep state realistic.
+    final realRef = firestore.collection('users').doc('user-1');
+    await realRef.set(<String, dynamic>{'a': 1, 'b': 2, 'c': 3});
+    recordingRef = _RecordingDocumentReference(realRef);
+    api = _RecordingApi(
+      firebaseFirestore: firestore,
+      collectionPath: () => 'users',
+      recordingRef: recordingRef,
+    );
+  });
+
+  group('TFirestoreApi.updateDoc', () {
+    test(
+      'Given previous and new writeables differ in one primitive, '
+      'when updateDoc is called with previousWriteable, '
+      'then the captured update receives only the changed key plus updatedAt',
+      () async {
+        final previous = _MapWriteable(<String, dynamic>{'a': 1, 'b': 2, 'c': 3});
+        final next = _MapWriteable(<String, dynamic>{'a': 1, 'b': 2, 'c': 99});
+
+        final response = await api.updateDoc(
+          writeable: next,
+          previousWriteable: previous,
+          id: 'user-1',
+        );
+
+        expect(response.isSuccess, isTrue);
+        expect(recordingRef.updateCallCount, 1);
+        final captured = recordingRef.capturedUpdate!;
+        expect(captured['c'], 99);
+        expect(captured.containsKey('a'), isFalse);
+        expect(captured.containsKey('b'), isFalse);
+        expect(captured.containsKey('updatedAt'), isTrue);
+      },
+    );
+
+    test(
+      'Given previous and new writeables produce identical maps, '
+      'when updateDoc is called with previousWriteable, '
+      'then update is never invoked and the response is success',
+      () async {
+        final previous = _MapWriteable(<String, dynamic>{'a': 1, 'b': 2});
+        final next = _MapWriteable(<String, dynamic>{'a': 1, 'b': 2});
+
+        final response = await api.updateDoc(
+          writeable: next,
+          previousWriteable: previous,
+          id: 'user-1',
+        );
+
+        expect(response.isSuccess, isTrue);
+        expect(recordingRef.updateCallCount, 0);
+        expect(recordingRef.capturedUpdate, isNull);
+      },
+    );
+
+    test(
+      'Given a nested map differs only in one sibling, '
+      'when updateDoc is called with previousWriteable, '
+      'then the captured update uses dot notation and omits unchanged siblings',
+      () async {
+        final previous = _MapWriteable(<String, dynamic>{
+          'profile': <String, dynamic>{
+            'name': 'A',
+            'email': 'a@x',
+          },
+        });
+        final next = _MapWriteable(<String, dynamic>{
+          'profile': <String, dynamic>{
+            'name': 'B',
+            'email': 'a@x',
+          },
+        });
+
+        final response = await api.updateDoc(
+          writeable: next,
+          previousWriteable: previous,
+          id: 'user-1',
+        );
+
+        expect(response.isSuccess, isTrue);
+        final captured = recordingRef.capturedUpdate!;
+        expect(captured['profile.name'], 'B');
+        expect(captured.containsKey('profile.email'), isFalse);
+        expect(captured.containsKey('profile'), isFalse);
+      },
+    );
+
+    test(
+      'Given previousWriteable is omitted, '
+      'when updateDoc is called, '
+      'then the captured update contains every key from the new payload',
+      () async {
+        final next = _MapWriteable(<String, dynamic>{
+          'a': 1,
+          'b': 2,
+          'c': 99,
+        });
+
+        final response = await api.updateDoc(
+          writeable: next,
+          id: 'user-1',
+        );
+
+        expect(response.isSuccess, isTrue);
+        final captured = recordingRef.capturedUpdate!;
+        expect(captured['a'], 1);
+        expect(captured['b'], 2);
+        expect(captured['c'], 99);
+        expect(captured.containsKey('updatedAt'), isTrue);
+      },
+    );
+
+    test(
+      'Given includeDeletes is true and a key is removed in the new map, '
+      'when updateDoc is called with previousWriteable, '
+      'then the captured update emits a FieldValue for the removed key',
+      () async {
+        final previous = _MapWriteable(<String, dynamic>{'a': 1, 'b': 2});
+        final next = _MapWriteable(<String, dynamic>{'a': 1});
+
+        final response = await api.updateDoc(
+          writeable: next,
+          previousWriteable: previous,
+          id: 'user-1',
+          includeDeletes: true,
+        );
+
+        expect(response.isSuccess, isTrue);
+        final captured = recordingRef.capturedUpdate!;
+        expect(captured['b'], isA<FieldValue>());
+        expect(captured.containsKey('a'), isFalse);
+      },
+    );
+  });
+
+  group('TFirestoreApi.updateDocInBatch', () {
+    test(
+      'Given previous and new writeables produce identical maps, '
+      'when updateDocInBatch is called with previousWriteable, '
+      'then the batch is never enqueued and the response is success',
+      () async {
+        final previous = _MapWriteable(<String, dynamic>{'a': 1, 'b': 2});
+        final next = _MapWriteable(<String, dynamic>{'a': 1, 'b': 2});
+        final recordingBatch = _RecordingWriteBatch();
+
+        final response = await api.updateDocInBatch(
+          writeable: next,
+          previousWriteable: previous,
+          id: 'user-1',
+          writeBatch: recordingBatch,
+        );
+
+        expect(response.isSuccess, isTrue);
+        expect(recordingBatch.updateCallCount, 0);
+        expect(recordingBatch.capturedUpdate, isNull);
+      },
+    );
+  });
+}

--- a/turbo_firestore_api/test/services/t_doc_service_test.dart
+++ b/turbo_firestore_api/test/services/t_doc_service_test.dart
@@ -1,0 +1,253 @@
+// ignore_for_file: invalid_use_of_protected_member
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:turbo_firestore_api/abstracts/t_model.dart';
+import 'package:turbo_firestore_api/apis/t_firestore_api.dart';
+import 'package:turbo_firestore_api/enums/t_timestamp_type.dart';
+import 'package:turbo_firestore_api/models/t_firestore_collection.dart';
+import 'package:turbo_firestore_api/services/t_doc_service.dart';
+import 'package:turbo_response/turbo_response.dart';
+import 'package:turbo_serializable/abstracts/t_writeable.dart';
+import 'package:turbo_serializable/abstracts/t_writeable_id.dart';
+
+/// Hand-rolled DTO that returns a preset map from [toJson].
+class _TestDto extends TWriteableId {
+  _TestDto({required this.id, required this.values});
+
+  @override
+  final String id;
+  final Map<String, dynamic> values;
+
+  @override
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(values);
+
+  _TestDto copyWith({Map<String, dynamic>? values}) =>
+      _TestDto(id: id, values: values ?? this.values);
+}
+
+/// Wrapper writeable produced by the [remoteUpdateRequestBuilder] in tests so
+/// the recorded `previousWriteable` payload differs from the raw DTO.
+class _WrappedWriteable extends TWriteable {
+  _WrappedWriteable(this._inner);
+
+  final _TestDto _inner;
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'wrapped': _inner.toJson(),
+      };
+}
+
+class _TestModel extends TModel<_TestDto> {
+  const _TestModel({required super.dto});
+}
+
+/// [TFirestoreApi] subclass that records every [updateDoc] call so the test
+/// can inspect the [previousWriteable] argument the service passed in.
+class _RecordingFirestoreApi extends TFirestoreApi<_TestDto> {
+  _RecordingFirestoreApi({
+    required super.firebaseFirestore,
+    required super.collectionPath,
+  });
+
+  TWriteable? recordedWriteable;
+  TWriteable? recordedPreviousWriteable;
+  bool didRecordCall = false;
+  int updateCallCount = 0;
+
+  @override
+  Future<TurboResponse<DocumentReference>> updateDoc({
+    required TWriteable writeable,
+    required String id,
+    TWriteable? previousWriteable,
+    WriteBatch? writeBatch,
+    TTimestampType timestampType = TTimestampType.updatedAt,
+    String? collectionPathOverride,
+    Transaction? transaction,
+    bool includeDeletes = false,
+  }) async {
+    updateCallCount++;
+    didRecordCall = true;
+    recordedWriteable = writeable;
+    recordedPreviousWriteable = previousWriteable;
+    final ref = getDocRefById(id: id);
+    return TurboResponse.success(result: ref);
+  }
+}
+
+/// Public-API wrapper that exposes the protected [updateDoc] for tests.
+class _TestableDocService extends TDocService<_TestDto, _TestModel> {
+  _TestableDocService({
+    required super.defaultValue,
+    required super.modelBuilder,
+    required super.apiBuilder,
+    super.initialValue,
+    required TFirestoreCollection<_TestDto> collection,
+  }) : super(collection: collection, initialiseStream: false);
+
+  Future<TurboResponse<_TestDto>> publicUpdateDoc({
+    required String id,
+    required _TestDto Function(_TestModel current) update,
+    TWriteable Function(_TestDto doc)? remoteUpdateRequestBuilder,
+  }) {
+    return updateDoc(
+      id: id,
+      doc: (current, _) => update(current),
+      remoteUpdateRequestBuilder: remoteUpdateRequestBuilder,
+    );
+  }
+}
+
+TFirestoreCollection<_TestDto> _buildCollection() => TFirestoreCollection<_TestDto>(
+      apiName: 'test',
+      collectionName: 'tests',
+      fromJson: (json) =>
+          _TestDto(id: json['id'] as String, values: Map<String, dynamic>.from(json)),
+      toJson: (dto) => dto.toJson(),
+    );
+
+_TestableDocService _buildService({
+  required _RecordingFirestoreApi recordingApi,
+  _TestDto? initialDto,
+}) {
+  final collection = _buildCollection();
+  return _TestableDocService(
+    collection: collection,
+    apiBuilder: (_, __, ___, ____) => recordingApi,
+    defaultValue: (vars, _, __) =>
+        _TestDto(id: vars.defaultId, values: const <String, dynamic>{}),
+    initialValue: initialDto == null ? null : (_, __, ___) => initialDto,
+    modelBuilder: (_, __, dto) => _TestModel(dto: dto),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeFirebaseFirestore firestore;
+  late _RecordingFirestoreApi recordingApi;
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    recordingApi = _RecordingFirestoreApi(
+      firebaseFirestore: firestore,
+      collectionPath: () => 'tests',
+    );
+  });
+
+  group('TDocService.updateDoc', () {
+    test(
+      'Given the notifier holds a DTO with a known shape, '
+      'when updateDoc mutates one field, '
+      'then the recorded previousWriteable serializes to the pre-mutation map',
+      () async {
+        final initial = _TestDto(
+          id: 'doc-1',
+          values: const <String, dynamic>{'a': 1, 'b': 2},
+        );
+        final service = _buildService(
+          recordingApi: recordingApi,
+          initialDto: initial,
+        );
+
+        final response = await service.publicUpdateDoc(
+          id: 'doc-1',
+          update: (current) => current.dto.copyWith(
+            values: <String, dynamic>{'a': 1, 'b': 3},
+          ),
+        );
+
+        expect(response.isSuccess, isTrue);
+        expect(recordingApi.updateCallCount, 1);
+        expect(recordingApi.recordedPreviousWriteable, isNotNull);
+        expect(
+          recordingApi.recordedPreviousWriteable!.toJson(),
+          <String, dynamic>{'a': 1, 'b': 2},
+        );
+        expect(
+          recordingApi.recordedWriteable!.toJson(),
+          <String, dynamic>{'a': 1, 'b': 3},
+        );
+
+        await service.dispose();
+      },
+    );
+
+    test(
+      'Given no initial DTO is provided so the notifier holds the default value, '
+      'when updateDoc is called, '
+      'then the recorded previousWriteable is the default DTO captured before the local mutation',
+      () async {
+        final service = _buildService(recordingApi: recordingApi);
+
+        final response = await service.publicUpdateDoc(
+          id: 'doc-1',
+          update: (current) => current.dto.copyWith(
+            values: <String, dynamic>{'a': 1},
+          ),
+        );
+
+        expect(response.isSuccess, isTrue);
+        expect(recordingApi.updateCallCount, 1);
+        // The default DTO is captured prior to the local mutation; its payload
+        // must be the empty default map, not the post-mutation map.
+        expect(recordingApi.recordedPreviousWriteable, isNotNull);
+        expect(
+          recordingApi.recordedPreviousWriteable!.toJson(),
+          isEmpty,
+        );
+        expect(
+          recordingApi.recordedWriteable!.toJson(),
+          <String, dynamic>{'a': 1},
+        );
+
+        await service.dispose();
+      },
+    );
+
+    test(
+      'Given a remoteUpdateRequestBuilder that wraps the DTO into a different shape, '
+      'when updateDoc is called against an existing previous DTO, '
+      'then the recorded previousWriteable is the builder output for the previous DTO (not the raw DTO)',
+      () async {
+        final initial = _TestDto(
+          id: 'doc-1',
+          values: const <String, dynamic>{'a': 1},
+        );
+        final service = _buildService(
+          recordingApi: recordingApi,
+          initialDto: initial,
+        );
+
+        final response = await service.publicUpdateDoc(
+          id: 'doc-1',
+          update: (current) => current.dto.copyWith(
+            values: <String, dynamic>{'a': 2},
+          ),
+          remoteUpdateRequestBuilder: _WrappedWriteable.new,
+        );
+
+        expect(response.isSuccess, isTrue);
+        expect(recordingApi.updateCallCount, 1);
+        expect(recordingApi.recordedPreviousWriteable, isA<_WrappedWriteable>());
+        expect(
+          recordingApi.recordedPreviousWriteable!.toJson(),
+          <String, dynamic>{
+            'wrapped': <String, dynamic>{'a': 1},
+          },
+        );
+        expect(recordingApi.recordedWriteable, isA<_WrappedWriteable>());
+        expect(
+          recordingApi.recordedWriteable!.toJson(),
+          <String, dynamic>{
+            'wrapped': <String, dynamic>{'a': 2},
+          },
+        );
+
+        await service.dispose();
+      },
+    );
+  });
+}

--- a/turbo_firestore_api/test/util/t_map_diff_test.dart
+++ b/turbo_firestore_api/test/util/t_map_diff_test.dart
@@ -1,0 +1,221 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:test/test.dart';
+import 'package:turbo_firestore_api/util/t_map_diff.dart';
+
+void main() {
+  group('TMapDiff.diff', () {
+    test(
+      'Given a key added in after, '
+      'when diffed against before without that key, '
+      'then the new key is emitted at the top level',
+      () {
+        final before = <String, dynamic>{'a': 1};
+        final after = <String, dynamic>{'a': 1, 'b': 2};
+
+        final result = TMapDiff.diff(before: before, after: after);
+
+        expect(result, {'b': 2});
+      },
+    );
+
+    test(
+      'Given a key removed in after with includeDeletes false, '
+      'when diffed, '
+      'then the result is empty',
+      () {
+        final before = <String, dynamic>{'a': 1, 'b': 2};
+        final after = <String, dynamic>{'a': 1};
+
+        final result = TMapDiff.diff(before: before, after: after);
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'Given a key removed in after with includeDeletes true, '
+      'when diffed, '
+      'then the path maps to a FieldValue.delete sentinel',
+      () {
+        final before = <String, dynamic>{'a': 1, 'b': 2};
+        final after = <String, dynamic>{'a': 1};
+
+        final result = TMapDiff.diff(
+          before: before,
+          after: after,
+          includeDeletes: true,
+        );
+
+        // FieldValue does not implement value equality and the public
+        // runtimeType resolves to the abstract `FieldValue` (the
+        // delete-specific subtype is private). Asserting `isA<FieldValue>()`
+        // on the only emitted entry is the cleanest signal that the diff
+        // produced a Firestore deletion sentinel.
+        expect(result.keys, ['b']);
+        expect(result['b'], isA<FieldValue>());
+      },
+    );
+
+    test(
+      'Given a primitive value changed, '
+      'when diffed, '
+      'then the new value is emitted at the top-level key',
+      () {
+        final before = <String, dynamic>{'a': 1};
+        final after = <String, dynamic>{'a': 2};
+
+        final result = TMapDiff.diff(before: before, after: after);
+
+        expect(result, {'a': 2});
+      },
+    );
+
+    test(
+      'Given a nested field changed, '
+      'when diffed, '
+      'then a single dot-notation entry is emitted',
+      () {
+        final before = <String, dynamic>{
+          'profile': <String, dynamic>{'name': 'old', 'age': 30},
+        };
+        final after = <String, dynamic>{
+          'profile': <String, dynamic>{'name': 'new', 'age': 30},
+        };
+
+        final result = TMapDiff.diff(before: before, after: after);
+
+        expect(result, {'profile.name': 'new'});
+      },
+    );
+
+    test(
+      'Given a list value changed, '
+      'when diffed, '
+      'then the whole list replaces the top-level key atomically',
+      () {
+        final before = <String, dynamic>{
+          'tags': <int>[1, 2, 3],
+        };
+        final after = <String, dynamic>{
+          'tags': <int>[1, 2, 4],
+        };
+
+        final result = TMapDiff.diff(before: before, after: after);
+
+        expect(result, {
+          'tags': <int>[1, 2, 4],
+        });
+      },
+    );
+
+    test(
+      'Given an unchanged list, '
+      'when diffed, '
+      'then the result is empty',
+      () {
+        final before = <String, dynamic>{
+          'tags': <int>[1, 2, 3],
+        };
+        final after = <String, dynamic>{
+          'tags': <int>[1, 2, 3],
+        };
+
+        final result = TMapDiff.diff(before: before, after: after);
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'Given an unchanged nested map, '
+      'when diffed, '
+      'then the result is empty',
+      () {
+        final before = <String, dynamic>{
+          'profile': <String, dynamic>{'name': 'same', 'age': 30},
+        };
+        final after = <String, dynamic>{
+          'profile': <String, dynamic>{'name': 'same', 'age': 30},
+        };
+
+        final result = TMapDiff.diff(before: before, after: after);
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'Given before is null, '
+      'when diffed, '
+      'then a shallow copy of after is returned',
+      () {
+        final after = <String, dynamic>{
+          'a': 1,
+          'profile': <String, dynamic>{'name': 'x'},
+        };
+
+        final result = TMapDiff.diff(before: null, after: after);
+
+        expect(result, {
+          'a': 1,
+          'profile': <String, dynamic>{'name': 'x'},
+        });
+      },
+    );
+
+    test(
+      'Given a change three levels deep, '
+      'when diffed, '
+      'then a single dot-notation entry like a.b.d is emitted',
+      () {
+        final before = <String, dynamic>{
+          'a': <String, dynamic>{
+            'b': <String, dynamic>{'c': 1, 'd': 2},
+          },
+        };
+        final after = <String, dynamic>{
+          'a': <String, dynamic>{
+            'b': <String, dynamic>{'c': 1, 'd': 99},
+          },
+        };
+
+        final result = TMapDiff.diff(before: before, after: after);
+
+        expect(result, {'a.b.d': 99});
+      },
+    );
+
+    test(
+      'Given a value type changed from int to string, '
+      'when diffed, '
+      'then the new value is emitted at the top-level key',
+      () {
+        final before = <String, dynamic>{'a': 1};
+        final after = <String, dynamic>{'a': '1'};
+
+        final result = TMapDiff.diff(before: before, after: after);
+
+        expect(result, {'a': '1'});
+      },
+    );
+
+    test(
+      'Given a new nested branch where the key is missing in before, '
+      'when diffed, '
+      'then the whole nested map is emitted at the top-level key without recursion',
+      () {
+        final before = <String, dynamic>{'a': 1};
+        final after = <String, dynamic>{
+          'a': 1,
+          'profile': <String, dynamic>{'name': 'x', 'age': 30},
+        };
+
+        final result = TMapDiff.diff(before: before, after: after);
+
+        expect(result, {
+          'profile': <String, dynamic>{'name': 'x', 'age': 30},
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #33 (PKG-32).

## Summary
- `TFirestoreApi.updateDoc` and `updateDocInBatch` accept new optional `previousWriteable` and `includeDeletes` parameters.
- When `previousWriteable` is provided, the payload sent to Firestore is reduced to a dot-notation diff via the new `TMapDiff` utility; no-op updates skip the Firestore write entirely on plain, transaction, and batch paths.
- `TDocService.updateDoc`, `TCollectionService.updateDoc`, and `TCollectionService.updateDocs` capture the pre-mutation DTO and forward it as `previousWriteable`, so service-layer consumers get the optimization automatically.
- `remoteUpdateRequestBuilder` is applied symmetrically to both the previous and new DTO so diff inputs share the same shape (deterministic builders required — documented in dartdoc).
- Direct callers of `TFirestoreApi.updateDoc` that do not pass `previousWriteable` keep byte-identical full-payload behavior. Fully backwards-compatible.

## Files
- `lib/util/t_map_diff.dart` (new) — recursive diff with deep equality, atomic list replace, optional `FieldValue.delete()`.
- `lib/apis/t_firestore_update_api.dart` — diff branch + skip-on-empty for plain, transaction, and batch paths.
- `lib/apis/t_firestore_api.dart` — import wiring for `TMapDiff`.
- `lib/services/t_doc_service.dart` — pre-mutation DTO capture + forwarding.
- `lib/services/t_collection_service.dart` — same wiring on `updateDoc` and `updateDocs`.
- `pubspec.yaml` — `collection: ^1.18.0` added as a direct dep.
- `test/util/t_map_diff_test.dart` (new, 12 cases).
- `test/apis/t_firestore_update_api_test.dart` (new, 6 cases incl. nested partial, no-op skip, `includeDeletes`, batch skip, backwards-compat).
- `test/services/t_doc_service_test.dart` (new, 3 cases incl. pre-mutation capture and `remoteUpdateRequestBuilder` symmetry).

## Acceptance criteria (PKG-32)
| AC | Proof |
| --- | --- |
| One field changed → only that field sent | `t_firestore_update_api_test.dart` "differs in one primitive" |
| Multiple fields changed → only those sent | `TMapDiff` unit tests + API tests combined |
| No fields changed → no Firestore write | `t_firestore_update_api_test.dart` no-op (`updateCallCount == 0`) |
| Unchanged fields preserved | Nested-partial test asserts `'profile.name'` present and `'profile.email'` / `'profile'` absent |
| App-visible behavior unchanged | Backwards-compat test (omit `previousWriteable` → full payload) |

## Test plan
- [x] `dart analyze` — 5 issues, all pre-existing, zero regressions.
- [x] `flutter test` — 75/75 pass (66 prior + 9 new).
- [x] Independent verifier review (flutter-reviewer): no critical/high findings; verdict ship.
- [ ] Reviewer sanity-check: nested partial preserves siblings on a real Firestore project.

## Notes
- `includeDeletes` defaults `false`. Set true to emit `FieldValue.delete()` for keys removed from the new payload.
- No-op updates do not tick `updatedAt`. If a caller wants forced touch, they can introduce a real change.
- `TPostDocService`, `TPreDocService`, `TPostCollectionService`, `TPreCollectionService` only override `onData`; they inherit the new wiring without modification.